### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   id = "paketo-buildpacks/pipenv"

--- a/detect_test.go
+++ b/detect_test.go
@@ -1,7 +1,6 @@
 package pipenv_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,10 +22,10 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(filepath.Join(workingDir, "Pipfile"), []byte{}, 0644)
+		err = os.WriteFile(filepath.Join(workingDir, "Pipfile"), []byte{}, 0644)
 		Expect(err).NotTo(HaveOccurred())
 
 		detect = pipenv.Detect()

--- a/pipenv_install_process_test.go
+++ b/pipenv_install_process_test.go
@@ -3,7 +3,6 @@ package pipenv_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,10 +27,10 @@ func testPipenvInstallProcess(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		srcPath, err = ioutil.TempDir("", "pipenv-source")
+		srcPath, err = os.MkdirTemp("", "pipenv-source")
 		Expect(err).NotTo(HaveOccurred())
 
-		destLayerPath, err = ioutil.TempDir("", "pipenv")
+		destLayerPath, err = os.MkdirTemp("", "pipenv")
 		Expect(err).NotTo(HaveOccurred())
 
 		executable = &fakes.Executable{}

--- a/site_process_test.go
+++ b/site_process_test.go
@@ -3,7 +3,6 @@ package pipenv_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ func testSiteProcess(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		targetLayerPath, err = ioutil.TempDir("", "pipenv")
+		targetLayerPath, err = os.MkdirTemp("", "pipenv")
 		Expect(err).NotTo(HaveOccurred())
 
 		executable = &fakes.Executable{}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
