### PR TITLE
Increase default timeout

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -106,7 +106,7 @@ func TestIntegration(t *testing.T) {
 		Execute(settings.Config.BuildPlan)
 	Expect(err).NotTo(HaveOccurred())
 
-	SetDefaultEventuallyTimeout(10 * time.Second)
+	SetDefaultEventuallyTimeout(20 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}))
 	suite("Default", testDefault, spec.Parallel())


### PR DESCRIPTION
## Summary

We observed since bumping the version of pipenv to 2022.1.8 that some of the integration test expectations consistently take longer than 10 seconds.

We haven't had a chance to observe why this is, but in the meantime we bumped the timeout to ensure the tests aren't flaky.

We will open an issue to investigate this timeout.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
