### PR TITLE
Respect `BP_PIPENV_VERSION` when choosing version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ The Paketo Pipenv Buildpack is a Cloud Native Buildpack that installs
 [pipenv](https://pypi.org/project/pipenv) into a layer and makes it available
 on the `PATH`.
 
-The buildpack is published for consumption at `gcr.io/paketo-buildpacks/pipenv`
-and `paketocommunity/pipenv`.
+The buildpack is published for consumption at `gcr.io/paketo-buildpacks/pipenv`.
 
 ## Behavior
 This buildpack always participates.
@@ -20,7 +19,7 @@ The buildpack will do the following:
 ## Configuration
 | Environment Variable | Description
 | -------------------- | -----------
-| `$BP_PIPENV_VERSION` | Configure the version of pipenv to install. Buildpack releases (and the pipenv versions for each release) can be found [here](https://github.com/paketo-buildpacks/pipenv/releases).
+| `$BP_PIPENV_VERSION` | Configure the version of pipenv to install. Buildpack releases (and the supported pipenv versions for each release) can be found [here](https://github.com/paketo-buildpacks/pipenv/releases).
 
 ## Integration
 
@@ -65,6 +64,12 @@ file that looks like the following:
 
 This buildpack requires internet connectivity to install `pipenv`. Installation
 in an air-gapped environment is not supported.
+
+The dependency URL metadata contained in `buildpack.toml` is not actually used,
+as `pipenv` is installed directly from the internet. However, the rest of the
+depedency metadata is used (e.g. for generating an SBOM). This will be
+addressed in upcoming work which will change the way dependencies are consumed
+by buildpacks.
 
 ## Usage
 

--- a/build_test.go
+++ b/build_test.go
@@ -175,21 +175,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			},
 		}))
 
-		Expect(dependencyManager.DeliverCall.Receives.Dependency).To(Equal(postal.Dependency{
-			ID:      "pipenv",
-			Name:    "pipenv-dependency-name",
-			SHA256:  "pipenv-dependency-sha",
-			Stacks:  []string{"some-stack"},
-			URI:     "pipenv-dependency-uri",
-			Version: "pipenv-dependency-version",
-		}))
-		Expect(dependencyManager.DeliverCall.Receives.CnbPath).To(Equal(cnbDir))
-		Expect(dependencyManager.DeliverCall.Receives.DestPath).To(ContainSubstring("pipenv-release"))
-		Expect(dependencyManager.DeliverCall.Receives.PlatformPath).To(Equal("some-platform-path"))
-
 		Expect(sbomGenerator.GenerateFromDependencyCall.Receives.Dir).To(Equal(filepath.Join(layersDir, "pipenv")))
 
-		Expect(installProcess.ExecuteCall.Receives.SrcPath).To(ContainSubstring("pipenv-release"))
+		Expect(installProcess.ExecuteCall.Receives.Version).To(ContainSubstring("pipenv-dependency-version"))
 		Expect(installProcess.ExecuteCall.Receives.DestLayerPath).To(Equal(filepath.Join(layersDir, "pipenv")))
 	})
 
@@ -276,7 +264,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(buffer.String()).To(ContainSubstring("Reusing cached layer"))
 
-			Expect(dependencyManager.DeliverCall.CallCount).To(Equal(0))
 			Expect(installProcess.ExecuteCall.CallCount).To(Equal(0))
 		})
 	})
@@ -323,17 +310,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				_, err := build(buildContext)
 
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
-			})
-		})
-
-		context("when dependency cannot be delivered", func() {
-			it.Before(func() {
-				dependencyManager.DeliverCall.Returns.Error = errors.New("failed to deliver dependency")
-			})
-			it("returns an error", func() {
-				_, err := build(buildContext)
-
-				Expect(err).To(MatchError(ContainSubstring("failed to deliver dependency")))
 			})
 		})
 

--- a/fakes/dependency_manager.go
+++ b/fakes/dependency_manager.go
@@ -8,20 +8,6 @@ import (
 )
 
 type DependencyManager struct {
-	DeliverCall struct {
-		mutex     sync.Mutex
-		CallCount int
-		Receives  struct {
-			Dependency   postal.Dependency
-			CnbPath      string
-			DestPath     string
-			PlatformPath string
-		}
-		Returns struct {
-			Error error
-		}
-		Stub func(postal.Dependency, string, string, string) error
-	}
 	GenerateBillOfMaterialsCall struct {
 		mutex     sync.Mutex
 		CallCount int
@@ -50,19 +36,6 @@ type DependencyManager struct {
 	}
 }
 
-func (f *DependencyManager) Deliver(param1 postal.Dependency, param2 string, param3 string, param4 string) error {
-	f.DeliverCall.mutex.Lock()
-	defer f.DeliverCall.mutex.Unlock()
-	f.DeliverCall.CallCount++
-	f.DeliverCall.Receives.Dependency = param1
-	f.DeliverCall.Receives.CnbPath = param2
-	f.DeliverCall.Receives.DestPath = param3
-	f.DeliverCall.Receives.PlatformPath = param4
-	if f.DeliverCall.Stub != nil {
-		return f.DeliverCall.Stub(param1, param2, param3, param4)
-	}
-	return f.DeliverCall.Returns.Error
-}
 func (f *DependencyManager) GenerateBillOfMaterials(param1 ...postal.Dependency) []packit.BOMEntry {
 	f.GenerateBillOfMaterialsCall.mutex.Lock()
 	defer f.GenerateBillOfMaterialsCall.mutex.Unlock()

--- a/fakes/install_process.go
+++ b/fakes/install_process.go
@@ -7,7 +7,7 @@ type InstallProcess struct {
 		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
-			SrcPath       string
+			Version       string
 			DestLayerPath string
 		}
 		Returns struct {
@@ -21,7 +21,7 @@ func (f *InstallProcess) Execute(param1 string, param2 string) error {
 	f.ExecuteCall.mutex.Lock()
 	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
-	f.ExecuteCall.Receives.SrcPath = param1
+	f.ExecuteCall.Receives.Version = param1
 	f.ExecuteCall.Receives.DestLayerPath = param2
 	if f.ExecuteCall.Stub != nil {
 		return f.ExecuteCall.Stub(param1, param2)

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -90,5 +90,6 @@ func TestIntegration(t *testing.T) {
 	suite := spec.New("Integration", spec.Report(report.Terminal{}))
 	suite("Default", testDefault, spec.Parallel())
 	suite("LayerReuse", testLayerReuse, spec.Parallel())
+	suite("Version", testVersions, spec.Parallel())
 	suite.Run(t)
 }

--- a/integration/versions_test.go
+++ b/integration/versions_test.go
@@ -1,0 +1,133 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testVersions(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	context("when the buildpack is run with pack build", func() {
+		var (
+			name   string
+			source string
+
+			containersMap map[string]interface{}
+			imagesMap     map[string]interface{}
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+
+			containersMap = map[string]interface{}{}
+			imagesMap = map[string]interface{}{}
+		})
+
+		it.After(func() {
+			for containerID := range containersMap {
+				Expect(docker.Container.Remove.Execute(containerID)).To(Succeed())
+			}
+			for imageID := range imagesMap {
+				Expect(docker.Image.Remove.Execute(imageID)).To(Succeed())
+			}
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it("builds and runs successfully with both provided dependency versions", func() {
+			var err error
+
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
+			Expect(err).NotTo(HaveOccurred())
+
+			firstPipenvVersion := buildpackInfo.Metadata.Dependencies[0].Version
+			secondPipenvVersion := buildpackInfo.Metadata.Dependencies[1].Version
+
+			Expect(firstPipenvVersion).NotTo(Equal(secondPipenvVersion))
+
+			firstImage, firstLogs, err := pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.CPython,
+					settings.Buildpacks.Pip,
+					settings.Buildpacks.Pipenv,
+					settings.Buildpacks.BuildPlan,
+				).
+				WithEnv(map[string]string{"BP_PIPENV_VERSION": firstPipenvVersion}).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), firstLogs.String)
+
+			imagesMap[firstImage.ID] = nil
+
+			Expect(firstLogs).To(ContainLines(
+				ContainSubstring(fmt.Sprintf(`Selected Pipenv version (using BP_PIPENV_VERSION): %s`, firstPipenvVersion)),
+			))
+
+			firstContainer, err := docker.Container.Run.
+				WithCommand("pipenv --version").
+				Execute(firstImage.ID)
+			Expect(err).ToNot(HaveOccurred())
+
+			containersMap[firstContainer.ID] = nil
+
+			Eventually(func() string {
+				cLogs, err := docker.Container.Logs.Execute(firstContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cLogs.String()
+			}).Should(ContainSubstring(fmt.Sprintf(`pipenv, version %s`, firstPipenvVersion)))
+
+			secondImage, secondLogs, err := pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.CPython,
+					settings.Buildpacks.Pip,
+					settings.Buildpacks.Pipenv,
+					settings.Buildpacks.BuildPlan,
+				).
+				WithEnv(map[string]string{"BP_PIPENV_VERSION": secondPipenvVersion}).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), secondLogs.String)
+
+			imagesMap[secondImage.ID] = nil
+
+			Expect(secondLogs).To(ContainLines(
+				ContainSubstring(fmt.Sprintf(`Selected Pipenv version (using BP_PIPENV_VERSION): %s`, secondPipenvVersion)),
+			))
+
+			secondContainer, err := docker.Container.Run.
+				WithCommand("pipenv --version").
+				Execute(secondImage.ID)
+			Expect(err).ToNot(HaveOccurred())
+
+			containersMap[secondContainer.ID] = nil
+
+			Eventually(func() string {
+				cLogs, err := docker.Container.Logs.Execute(secondContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cLogs.String()
+			}).Should(ContainSubstring(fmt.Sprintf(`pipenv, version %s`, secondPipenvVersion)))
+		})
+	})
+}

--- a/pipenv_install_process.go
+++ b/pipenv_install_process.go
@@ -26,14 +26,13 @@ func NewPipenvInstallProcess(executable Executable) PipenvInstallProcess {
 	}
 }
 
-// Execute installs the pipenv binary from source code located in the given
-// srcPath into the layer path designated by targetLayerPath.
-func (p PipenvInstallProcess) Execute(srcPath, targetLayerPath string) error {
+// Execute installs the provided version of pipenv from the internet into the
+// layer path designated by targetLayerPath
+func (p PipenvInstallProcess) Execute(version, targetLayerPath string) error {
 	buffer := bytes.NewBuffer(nil)
 
 	err := p.executable.Execute(pexec.Execution{
-		// Install pipenv from source with the pip that comes from a previous buildpack
-		Args: []string{"install", "pipenv", "--user", fmt.Sprintf("--find-links=%s", srcPath)},
+		Args: []string{"install", fmt.Sprintf("pipenv==%s", version), "--user"},
 		// Set the PYTHONUSERBASE to ensure that pip is installed to the newly created target layer.
 		Env:    append(os.Environ(), fmt.Sprintf("PYTHONUSERBASE=%s", targetLayerPath)),
 		Stdout: buffer,

--- a/pipenv_install_process_test.go
+++ b/pipenv_install_process_test.go
@@ -18,7 +18,7 @@ func testPipenvInstallProcess(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		srcPath       string
+		version       string
 		destLayerPath string
 		executable    *fakes.Executable
 
@@ -27,11 +27,10 @@ func testPipenvInstallProcess(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		srcPath, err = os.MkdirTemp("", "pipenv-source")
-		Expect(err).NotTo(HaveOccurred())
-
 		destLayerPath, err = os.MkdirTemp("", "pipenv")
 		Expect(err).NotTo(HaveOccurred())
+
+		version = "1.2.3-some.version"
 
 		executable = &fakes.Executable{}
 
@@ -41,11 +40,11 @@ func testPipenvInstallProcess(t *testing.T, context spec.G, it spec.S) {
 	context("Execute", func() {
 		context("there is a pipenv dependency to install", func() {
 			it("installs it to the pipenv layer", func() {
-				err := pipenvInstallProcess.Execute(srcPath, destLayerPath)
+				err := pipenvInstallProcess.Execute(version, destLayerPath)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(executable.ExecuteCall.Receives.Execution.Env).To(Equal(append(os.Environ(), fmt.Sprintf("PYTHONUSERBASE=%s", destLayerPath))))
-				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{"install", "pipenv", "--user", fmt.Sprintf("--find-links=%s", srcPath)}))
+				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{"install", "pipenv==1.2.3-some.version", "--user"}))
 			})
 		})
 
@@ -60,7 +59,7 @@ func testPipenvInstallProcess(t *testing.T, context spec.G, it spec.S) {
 				})
 
 				it("returns an error", func() {
-					err := pipenvInstallProcess.Execute(srcPath, destLayerPath)
+					err := pipenvInstallProcess.Execute(version, destLayerPath)
 					Expect(err).To(MatchError(ContainSubstring("installing pipenv failed")))
 					Expect(err).To(MatchError(ContainSubstring("stdout output")))
 					Expect(err).To(MatchError(ContainSubstring("stderr output")))


### PR DESCRIPTION
## Summary

We observed in #221 that we do not respect `BP_PIPENV_VERSION` - we just install the latest version from the internet.

This PR fixes that by installing `pipenv` via `pip install pipenv==<version>`. We also stop downloading the dependency tarball as we no longer use it. We also add an integration test explicitly testing that we install each of the versions declared in the `buildpack.toml`.

One gotcha with this PR is that the dependency URL/SHA in the `buildpack.toml` are a bit misleading, as we no longer interact with that file. However, changing that requires non-trivial changes to this buildpack, dependency automation, and potentially SBOM generation. We keep the `buildpack.toml` as-is to avoid the automation overwriting any manual changes. We expect the way we handle dependencies to change with the upcoming dependencies changes work, so any effort now would be wasted.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
