### PR TITLE
Use occam.Source in integration tests.

### DIFF
--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -40,6 +40,9 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		it.After(func() {
@@ -52,9 +55,6 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 		it("builds and runs successfully", func() {
 			var err error
 			var logs fmt.Stringer
-
-			source, err = occam.Source(filepath.Join("testdata", "default_app"))
-			Expect(err).NotTo(HaveOccurred())
 
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
@@ -134,7 +134,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 						"BP_LOG_LEVEL": "DEBUG",
 					}).
 					WithSBOMOutputDir(sbomDir).
-					Execute(name, filepath.Join("testdata", "default_app"))
+					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
 				container, err = docker.Container.Run.

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -39,6 +39,9 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 		imageIDs = map[string]struct{}{}
 		containerIDs = map[string]struct{}{}
+
+		source, err = occam.Source(filepath.Join("testdata", "default_app"))
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	it.After(func() {
@@ -58,18 +61,14 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 	context("when the app is rebuilt and the same pipenv version is required", func() {
 		it("reuses the cached pipenv layer", func() {
 			var (
-				err    error
-				logs   fmt.Stringer
-				source string
+				err  error
+				logs fmt.Stringer
 
 				firstImage  occam.Image
 				secondImage occam.Image
 
 				secondContainer occam.Container
 			)
-
-			source, err = occam.Source(filepath.Join("testdata", "default_app"))
-			Expect(err).ToNot(HaveOccurred())
 
 			firstImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
@@ -122,18 +121,14 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 	context("when the app is rebuilt and a different pipenv version is required", func() {
 		it("rebuilds", func() {
 			var (
-				err    error
-				logs   fmt.Stringer
-				source string
+				err  error
+				logs fmt.Stringer
 
 				firstImage  occam.Image
 				secondImage occam.Image
 
 				secondContainer occam.Container
 			)
-
-			source, err = occam.Source(filepath.Join("testdata", "default_app"))
-			Expect(err).ToNot(HaveOccurred())
 
 			firstImage, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").


### PR DESCRIPTION
## Summary

This PR ensures that each test uses `occam.Source` in a consistent manner. This ensures that we do not accidentally re-use images across tests.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
