### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pipenv Cloud Native Buildpack
-The Paketo Pipenv Buildpack is a Cloud Native Buildpack that installs
+The Paketo Buildpack for Pipenv is a Cloud Native Buildpack that installs
 [pipenv](https://pypi.org/project/pipenv) into a layer and makes it available
 on the `PATH`.
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.7"
 
 [buildpack]
   id = "paketo-buildpacks/pipenv"
-  name = "Paketo Pipenv Buildpack"
+  name = "Paketo Buildpack for Pipenv"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Pipenv Buildpack' to 'Paketo Buildpack for Pipenv'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
